### PR TITLE
[Refactor/38]비교적 큰 크기의 모바일 기종의 반응형 UI 개선

### DIFF
--- a/src/components/ui/page-layout.tsx
+++ b/src/components/ui/page-layout.tsx
@@ -16,7 +16,7 @@ export function PageLayout({
 }: PageLayoutProps) {
   return (
     <div
-      className={`relative flex h-full w-full flex-col pt-26 sm:pt-36 md:pt-40 ${className}`}
+      className={`dynamic-padding-top relative flex h-full w-full flex-col min-[451px]:md:pt-48 min-[451px]:sm:pt-44 ${className}`}
     >
       <BackButton />
       <p className="mt-3 font-primary text-[32px] text-red-200 leading-12">

--- a/src/components/ui/search-input.tsx
+++ b/src/components/ui/search-input.tsx
@@ -10,7 +10,7 @@ const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
   ({ className, ...props }, ref) => {
     return (
       <div
-        className={cn("relative flex h-12 w-[360px] items-center", className)}
+        className={cn("relative flex h-12 w-[412px] items-center", className)}
       >
         <LensIcon className="pointer-events-none absolute left-4 h-[18px] w-[18px] text-gray-700" />
         <input

--- a/src/index.css
+++ b/src/index.css
@@ -179,3 +179,12 @@
   --color-opacity-r100-3: rgb(142 45 45 / 0.03);
   --color-opacity-b100-10: rgb(142 45 45 / 0.1);
 }
+
+/* Dynamic padding for responsive height */
+.dynamic-padding-top {
+  padding-top: max(6.5rem, calc(6.5rem + (100vh - 690px) * 0.3));
+}
+
+.dynamic-bottom-position {
+  bottom: max(89px, calc(89px + (100vh - 660px) * 0.3));
+}

--- a/src/layouts/AppShell.tsx
+++ b/src/layouts/AppShell.tsx
@@ -20,7 +20,7 @@ export default function AppShell({ children }: PropsWithChildren) {
       className={`h-dvh overflow-hidden ${isLetterSearch ? "bg-white text-black" : "bg-[#412716] text-white"}`}
     >
       <main
-        className={`mx-auto h-full w-full max-w-[393px] bg-center bg-cover bg-no-repeat ${shouldRemovePadding ? "" : "p-4"}`}
+        className={`mx-auto h-full w-full max-w-[450px] bg-center bg-cover bg-no-repeat ${shouldRemovePadding ? "" : "p-4"}`}
         style={bgUrl ? { backgroundImage: `url(${bgUrl})` } : undefined}
       >
         {children}

--- a/src/pages/joinPage/pages/join-nickname-page.tsx
+++ b/src/pages/joinPage/pages/join-nickname-page.tsx
@@ -35,7 +35,7 @@ export default function JoinNicknamePage() {
       </p>
 
       <NicknameInput 
-        className="mt-3" 
+        className="mt-8" 
         value={nickname}
         onChange={setNickname}
         maxLength={6}

--- a/src/pages/joinPage/pages/join-nickname-page.tsx
+++ b/src/pages/joinPage/pages/join-nickname-page.tsx
@@ -5,8 +5,9 @@ import { PageLayout } from "@/components/ui/page-layout";
 
 export default function JoinNicknamePage() {
   const [nickname, setNickname] = useState("");
-  
-  const isNicknameValid = nickname.trim().length > 0 && nickname.trim().length <= 6;
+
+  const isNicknameValid =
+    nickname.trim().length > 0 && nickname.trim().length <= 6;
 
   return (
     <PageLayout
@@ -20,8 +21,8 @@ export default function JoinNicknamePage() {
         </>
       }
       bottomContent={
-        <NavigationButton 
-          className="w-full" 
+        <NavigationButton
+          className="w-full"
           active={isNicknameValid}
           disabled={!isNicknameValid}
           aria-disabled={!isNicknameValid}
@@ -34,8 +35,8 @@ export default function JoinNicknamePage() {
         다른 사람에게 보이는 별명이에요!
       </p>
 
-      <NicknameInput 
-        className="mt-8" 
+      <NicknameInput
+        className="mt-8"
         value={nickname}
         onChange={setNickname}
         maxLength={6}

--- a/src/pages/letterPage/components/letter-step.tsx
+++ b/src/pages/letterPage/components/letter-step.tsx
@@ -1,6 +1,7 @@
 interface LetterStepProps {
   step: 1 | 2;
   className?: string;
+  style?: React.CSSProperties;
 }
 
 const COMMON_STYLES = {
@@ -32,11 +33,11 @@ const STEP_DATA = [
   },
 ] as const;
 
-export default function LetterStep({ step = 1, className }: LetterStepProps) {
+export default function LetterStep({ step = 1, className, style }: LetterStepProps) {
   const stepData = STEP_DATA[step - 1];
 
   return (
-    <div className={`flex flex-col items-center ${className}`}>
+    <div className={`flex flex-col items-center ${className}`} style={style}>
       <div className={COMMON_STYLES.container}>
         <div className={`${COMMON_STYLES.text} ${stepData.textPosition}`}>
           {stepData.label}

--- a/src/pages/letterPage/components/letter-step.tsx
+++ b/src/pages/letterPage/components/letter-step.tsx
@@ -33,7 +33,11 @@ const STEP_DATA = [
   },
 ] as const;
 
-export default function LetterStep({ step = 1, className, style }: LetterStepProps) {
+export default function LetterStep({
+  step = 1,
+  className,
+  style,
+}: LetterStepProps) {
   const stepData = STEP_DATA[step - 1];
 
   return (

--- a/src/pages/letterPage/pages/letter-complete-page.tsx
+++ b/src/pages/letterPage/pages/letter-complete-page.tsx
@@ -12,9 +12,7 @@ export default function LetterCompletePage() {
   };
 
   return (
-    <div 
-      className="dynamic-padding-top relative flex h-full w-full flex-col min-[451px]:md:pt-48 min-[451px]:sm:pt-44"
-    >
+    <div className="dynamic-padding-top relative flex h-full w-full flex-col min-[451px]:md:pt-48 min-[451px]:sm:pt-44">
       <p className="mt-3 text-center font-primary text-[32px] text-red-200 leading-12">
         마음이 담긴 첫 곡이 <br />
         성공적으로 전송됐어요. <br />

--- a/src/pages/letterPage/pages/letter-complete-page.tsx
+++ b/src/pages/letterPage/pages/letter-complete-page.tsx
@@ -12,7 +12,9 @@ export default function LetterCompletePage() {
   };
 
   return (
-    <div className="relative flex h-full w-full flex-col pt-26 sm:pt-36 md:pt-40">
+    <div 
+      className="dynamic-padding-top relative flex h-full w-full flex-col min-[451px]:md:pt-48 min-[451px]:sm:pt-44"
+    >
       <p className="mt-3 text-center font-primary text-[32px] text-red-200 leading-12">
         마음이 담긴 첫 곡이 <br />
         성공적으로 전송됐어요. <br />

--- a/src/pages/letterPage/pages/letter-write-page.tsx
+++ b/src/pages/letterPage/pages/letter-write-page.tsx
@@ -14,8 +14,8 @@ export default function LetterWritePage() {
   const [letterContent, setLetterContent] = useState("");
   const [authorName, setAuthorName] = useState("");
 
-  const isFormValid = 
-    letterContent.trim() !== "" && 
+  const isFormValid =
+    letterContent.trim() !== "" &&
     authorName.trim() !== "" &&
     letterContent.length <= 50 &&
     authorName.length <= 18;
@@ -62,14 +62,10 @@ export default function LetterWritePage() {
           className="dynamic-padding-top absolute top-0 right-0 p-4"
         />
 
-        <SideDiskIcon 
-          className="dynamic-bottom-position absolute right-0" 
-        />
+        <SideDiskIcon className="dynamic-bottom-position absolute right-0" />
 
         {/* 음악 앨범 사진 */}
-        <div 
-          className="-translate-y-[90.625px] dynamic-bottom-position absolute right-0 h-[108.75px] w-[108.75px] overflow-hidden rounded-md bg-gray-300"
-        >
+        <div className="-translate-y-[90.625px] dynamic-bottom-position absolute right-0 h-[108.75px] w-[108.75px] overflow-hidden rounded-md bg-gray-300">
           <img
             src="/path/to/album-image.jpg"
             alt="앨범 커버"
@@ -85,9 +81,7 @@ export default function LetterWritePage() {
         />
 
         {/* 편지지 내부 콘텐츠 영역 */}
-        <div 
-          className="dynamic-bottom-position absolute z-20 h-[294px] w-[294px] px-5 py-5"
-        >
+        <div className="dynamic-bottom-position absolute z-20 h-[294px] w-[294px] px-5 py-5">
           {/* To. 닉네임 - 좌측 상단 */}
           <div className="absolute top-5 left-5 font-letter text-black text-xs">
             To. 닉네임

--- a/src/pages/letterPage/pages/letter-write-page.tsx
+++ b/src/pages/letterPage/pages/letter-write-page.tsx
@@ -59,13 +59,17 @@ export default function LetterWritePage() {
       >
         <LetterStep
           step={2}
-          className="absolute top-0 right-0 p-4 pt-26 sm:pt-36 md:pt-40"
+          className="dynamic-padding-top absolute top-0 right-0 p-4"
         />
 
-        <SideDiskIcon className="absolute right-0 bottom-[89px]" />
+        <SideDiskIcon 
+          className="dynamic-bottom-position absolute right-0" 
+        />
 
         {/* 음악 앨범 사진 */}
-        <div className="-translate-y-[90.625px] absolute right-0 bottom-[89px] h-[108.75px] w-[108.75px] overflow-hidden rounded-md bg-gray-300">
+        <div 
+          className="-translate-y-[90.625px] dynamic-bottom-position absolute right-0 h-[108.75px] w-[108.75px] overflow-hidden rounded-md bg-gray-300"
+        >
           <img
             src="/path/to/album-image.jpg"
             alt="앨범 커버"
@@ -77,11 +81,13 @@ export default function LetterWritePage() {
           src={LetterPaperBg}
           alt=""
           aria-hidden="true"
-          className="absolute bottom-[89px] z-10 select-none"
+          className="dynamic-bottom-position absolute z-10 select-none"
         />
 
         {/* 편지지 내부 콘텐츠 영역 */}
-        <div className="absolute bottom-[89px] z-20 h-[294px] w-[294px] px-5 py-5">
+        <div 
+          className="dynamic-bottom-position absolute z-20 h-[294px] w-[294px] px-5 py-5"
+        >
           {/* To. 닉네임 - 좌측 상단 */}
           <div className="absolute top-5 left-5 font-letter text-black text-xs">
             To. 닉네임


### PR DESCRIPTION
<!-- PR 제목은 "[태그/#이슈번호] 작업 내용 요약" 으로 작성해주세요 -->
<!-- ex) [FEAT/#1] 로그인 페이지 UI 구현 -->

## Summary

> #38 
- 반응형 UI 최적화

## Tasks

가로 길이 450px(아이폰 14 pro가 430, 삼성 울트라가 412이며 대부분의 모바일 기종은 그 이하입니다)

## Screenshot

<img width="1129" height="778" alt="image" src="https://github.com/user-attachments/assets/cbc1d9a5-1ce2-4a80-ba6e-2761711fb330" />

<img width="1130" height="775" alt="image" src="https://github.com/user-attachments/assets/3a2b1338-b507-465a-be03-c92fda9684a6" />

<img width="1129" height="776" alt="image" src="https://github.com/user-attachments/assets/29e67943-15a3-4b7b-be6a-02f1625dec5c" />

<img width="1129" height="776" alt="image" src="https://github.com/user-attachments/assets/e08fd270-363d-470f-9e4b-910328a962cf" />

<img width="1132" height="777" alt="image" src="https://github.com/user-attachments/assets/d1b7e3bb-cf0b-4707-954d-b0c95e62ae4f" />

<img width="1130" height="776" alt="image" src="https://github.com/user-attachments/assets/8cf15e8e-52df-467b-8fe8-53626e371880" />
